### PR TITLE
Remove duplicate security policy in issue contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
   - name: Protocol requests
     url: https://github.com/stellar/stellar-protocol
     about: Propose changes to the Stellar protocol or ecosystem standards
-  - name: Report a security vulnerability
-    url: https://www.stellar.org/community/bug-bounty-program/
-    about: Review our security policy for more details


### PR DESCRIPTION
### What
Remove the security policy link from the contact links in the issue templates config.

### Why
We have a security policy on most repositories and that results in two links showing up when creating new issues.

<img width="738" alt="Screen Shot 2019-11-15 at 2 35 09 PM" src="https://user-images.githubusercontent.com/351529/68980406-42d5bc00-07b5-11ea-9153-c0a4013df7b6.png">
