### PR TITLE
Change feature request label to spaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Tell us what you'd like to see
 title: 'Feature Request: '
-labels: 'feature-request'
+labels: 'feature request'
 
 ---
 


### PR DESCRIPTION
### What
Change the label that is assigned to new feature requests to use a space instead of a hyphen.

### Why
We use spaces as the separator on all our labels, and both approaches are common on GitHub projects to there is little advantage to making this one different to all our other ones.

I had gone with a hyphenated one because it can be easier to use when running queries, but since we are using spaces so heavily and the default issue labels that GitHub creates uses spaces it seems like a non-issue to use spaces.