### PR TITLE
Allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Ask a question
     url: https://stellar.stackexchange.com/questions/ask


### PR DESCRIPTION
### What
Allow blank issues.

### Why
I set this to false without really thinking about it, to be honest I
think it was a copy and paste from a GitHub example. Having it set to
false means somebody is forced to use one of the templates. Having it
set to true means somebody can click a little link at the bottom under
the template buttons that opens a blank issue. The main reason to have
templates is to encourage contributors to write good bug and feature
requests, but sometimes there are problems that need discussions in an
issue that do not fit those templates well and we should allow ourselves
to create whatever content we need.