### PR TITLE
Add link to stellar-dev mailing list to issues page of our repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://stellar.stackexchange.com/questions/ask
     about: Please ask questions here
   - name: Developer Mailing List
-    url: https://stellar.stackexchange.com/questions/ask
+    url: https://groups.google.com/g/stellar-dev
     about: Discuss Core Advancement Proposals (CAPs) and Stellar Ecosystem Proposals (SEPs) and talk about development of stellar-core, Horizon, and the rest of the Stellar platform. A place for conversations that move the protocol and ecosystem forward.
   - name: Protocol requests
     url: https://github.com/stellar/stellar-protocol

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ contact_links:
   - name: Ask a question
     url: https://stellar.stackexchange.com/questions/ask
     about: Please ask questions here
-  - name: Developer Mailing List
+  - name: Developer mailing list
     url: https://groups.google.com/g/stellar-dev
     about: Discuss Core Advancement Proposals (CAPs) and Stellar Ecosystem Proposals (SEPs) and talk about development of stellar-core, Horizon, and the rest of the Stellar platform. A place for conversations that move the protocol and ecosystem forward.
   - name: Protocol requests

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Ask a question
     url: https://stellar.stackexchange.com/questions/ask
     about: Please ask questions here
+  - name: Developer Mailing List
+    url: https://stellar.stackexchange.com/questions/ask
+    about: Discuss Core Advancement Proposals (CAPs) and Stellar Ecosystem Proposals (SEPs) and talk about development of stellar-core, Horizon, and the rest of the Stellar platform. A place for conversations that move the protocol and ecosystem forward.
   - name: Protocol requests
     url: https://github.com/stellar/stellar-protocol
-    about: Propose changes to the Stellar protocol or ecosystem standards
+    about: Propose changes to the Stellar protocol (CAPs) or ecosystem (SEPs) standards


### PR DESCRIPTION
### What
Add link to stellar-dev mailing list to issues page of our repos.

### Why
We don't point people to the stellar-dev mailing list on our repos but
we want people to use the mailing list for discussion. We should promote
it front and center when people are thinking of communicating with us on
GitHub. In some ways I think it is more important than the link to the
stellar-protocol repo that we have in this list.