### PR TITLE
Add contributions section to Code of Conduct to replace CLA

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -84,6 +84,15 @@ details please see our reporting guidelines below.
   us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 * Most of all, **be excellent to each other.**
 
+## Contributions to Open Source Software
+If you are contributing to a Stellar open source development project, which is managed by Stellar
+Development Foundation ("Stellar OSS"), then you acknowledge that all your contributions  are
+contributed by you under the Apache 2.0 license. If your employer(s) has rights to intellectual
+property that you create that includes your contributions to Stellar OSS, you represent that you
+have received permission to make your contributions on behalf of that employer, that your employer
+has waived such rights for your contributions to SDF, or that your employer has executed a separate
+agreement with SDF.
+
 ## Diversity Statement
 We encourage everyone to participate and are committed to building a community for all. We are
 committed to being a community that everyone feels good about joining. Although we may not be able

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,6 @@ Of course, feel free to create a new issue if you think something needs to be ad
 
 ## Submitting Changes
 
-* [Sign the Contributor License Agreement][cla].
 * All content, comments, and pull requests must follow the [Stellar Community
   Guidelines][community-guidelines] and [Code of Conduct][coc]
 * Push your changes to a topic branch in your fork of the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ Of course, feel free to create a new issue if you think something needs to be ad
 
 ## Submitting Changes
 
-* All content, comments, and pull requests must follow the [Stellar Community
-  Guidelines][community-guidelines] and [Code of Conduct][coc]
+* All content, comments, pull requests and other contributions must comply with the
+  [Stellar Code of Conduct][coc].
 * Push your changes to a topic branch in your fork of the repository.
 * Submit a pull request to the [docs repository](https://github.com/stellar/docs) in the Stellar
   organization.
@@ -64,7 +64,6 @@ alternatives.
 * [Explore the API](https://www.stellar.org/developers/reference/)
 * [Stack Exchange](http://stellar.stackexchange.com/)
 * #dev-discussion channel on [Keybase](https://keybase.io/team/stellar.public)
-* [Contributor License Agreement][cla]
 
 This document is inspired by:
 
@@ -74,6 +73,4 @@ This document is inspired by:
 
 [help-wanted]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Astellar+label%3A%22help+wanted%22
 [commit-msg]: https://github.com/erlang/otp/wiki/Writing-good-commit-messages
-[cla]: https://docs.google.com/forms/d/1g7EF6PERciwn7zfmfke5Sir2n10yddGGSXyZsq98tVY/viewform?usp=send_form
-[community-guidelines]: https://www.stellar.org/community-guidelines/
 [coc]: https://github.com/stellar/.github/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
### What
Add contributions section to Code of Conduct and remove statement about the Contributor License Agreement.

### Why
The legal team provided me with this text to add to the code of conduct so that the CLA could be deprecated.