### PR TITLE
Add profile readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,5 @@
-<div align="center">
 <h1><img alt="Stellar" src="https://github.com/stellar/.github/raw/master/stellar-logo.png" width="558" /></h1>
 <br/>
-</div>
 
 Stellar is an open network for storing and moving money, creating equitable access to the global financial system.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,21 @@
+<div align="center">
+<h1><img alt="Stellar" src="https://github.com/stellar/.github/raw/master/stellar-logo.png" width="558" /></h1>
+<br/>
+</div>
+
+Stellar is an open network for storing and moving money, creating equitable access to the global financial system.
+
+Stellar makes it possible to create, send, and trade digital representations of all forms of money: dollars, pesos, bitcoin, pretty much anything. It’s designed so all the world’s financial systems can work together on a single network.
+
+Stellar is open source.
+
+- [Learn more](https://www.stellar.org/learn/intro-to-stellar)
+- [Mailing list](https://groups.google.com/g/stellar-dev)
+- [Protocol proposals](https://github.com/stellar/stellar-protocol)
+- [Ask a question](https://stellar.stackexchange.com/questions/ask)
+
+Integrate:
+
+- [Developers](https://www.stellar.org/developers)
+- [API Reference](https://developers.stellar.org/api)
+- [SDKs](https://developers.stellar.org/docs/software-and-sdks/)

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,6 +7,8 @@ Stellar makes it possible to create, send, and trade digital representations of 
 
 Stellar is open source.
 
+Get involved:
+
 - [Learn more](https://www.stellar.org/learn/intro-to-stellar)
 - [Mailing list](https://groups.google.com/g/stellar-dev)
 - [Protocol proposals](https://github.com/stellar/stellar-protocol)


### PR DESCRIPTION
### What
Add a profile readme that will display on github.com/stellar.

### Why
GitHub released the ability for us to create profile readmes. Here is an example of one that Twitter is using: github.com/twitter. It can be helpful to link from the profile readme to all the typical places we try to direct folks like the mailing list, docs, where to ask questions. We link to most of these places on the "New Issue" screens of repos to increase discoverability of them, and this would be a good place too.

Most of the copy I copied from stellar.org and I imagine other folks may wish to improve it.