### PR TITLE
Remove Feature Request prefix on feature request titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Tell us what you'd like to see
-title: 'Feature Request: '
+title: ''
 labels: 'feature request'
 
 ---


### PR DESCRIPTION
### What
Remove `Feature Request: ` prefix on feature request titles.

### Why
They're unnecessary. We label issues as feature requests. Many of the issues we create are already feature requests, and it is unnecessary to label externally created issues differently than issues we create internally. Also, some repos like the stellar/go repo use different prefix schemes ([example](https://github.com/stellar/go/blob/master/CONTRIBUTING.md#issues)), so its better to impose no prefix and let the creator specify an appropriate title.