### PR TITLE
Add link to StellarDev Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,14 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Ask a question
+  - name: Ask a question on Stack Exchange
     url: https://stellar.stackexchange.com/questions/ask
-    about: Please ask questions here
-  - name: Developer mailing list
+    about: Ask questions, find answers.
+  - name: Join the Developer Discord
+    url: https://discord.gg/ksfVcEB4nA
+    about: Chat, collaborate, engage.
+  - name: Join the Developer mailing list
     url: https://groups.google.com/g/stellar-dev
     about: Discuss Core Advancement Proposals (CAPs) and Stellar Ecosystem Proposals (SEPs) and talk about development of stellar-core, Horizon, and the rest of the Stellar platform. A place for conversations that move the protocol and ecosystem forward.
-  - name: Protocol requests
+  - name: Protocol proposals
     url: https://github.com/stellar/stellar-protocol
     about: Propose changes to the Stellar protocol (CAPs) or ecosystem (SEPs) standards

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,6 +10,7 @@ Get involved:
 - [Mailing list](https://groups.google.com/g/stellar-dev)
 - [Protocol proposals](https://github.com/stellar/stellar-protocol)
 - [Ask a question](https://stellar.stackexchange.com/questions/ask)
+- [Join the developers Discord](https://discord.gg/ksfVcEB4nA)
 
 Integrate:
 


### PR DESCRIPTION
### What
Add a link to StellarDev Discord on the issues page of all our repos alongside the link to stack exchange and the mailing list. Add link to the GitHub profile readme also.

### Why

I think this could help with discoverability. Defer to the ecosystem folks, of which I've mentioned a few here:

@rice2000 @tyvdh @sandrapersing 