### PR TITLE
all: Encorage bug submitters to add exact commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ JS: Check `yarn.lock` or `package-lock.json` to find out precisely what version 
 Go: Check `go.mod` or `go list -m`.
 -->
 
-### What did you do?
+### What did you do (add exact commands if possible)?
 
 <!--
 If possible, provide a recipe for reproducing the error.


### PR DESCRIPTION
In recent bug reports it would had been great to get exact the exact commands leading to the problem.