### PR TITLE
Add comment about what version information to provide for CLIs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,7 @@ labels: bug
 ### What version are you using?
 
 <!--
+CLI: Share the output of `[cli] version`, for example: `soroban version`.
 JS: Check `yarn.lock` or `package-lock.json` to find out precisely what version of the SDK you're running.
 Go: Check `go.mod` or `go list -m`.
 -->


### PR DESCRIPTION
### What
Add a comment about what version info to include for CLIs on issues.

### Why
To encourage folks to post the output of CLI version commands which is an easy way to make sure we know which version is in use when the bug is seen.