### PR TITLE
📝 Refresh older Foundation reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ The first place to start is always looking over the current GitHub issues for th
 interested in contributing to. Issues marked with [help wanted][help-wanted] or are usually pretty
 self-contained and a good place to get started.
 
-Stellar.org also uses these same GitHub issues to keep track of what we are working on. If you see
-any issues that are assigned to a particular person or have the `in progress` label, that means
-someone is currently working on that issue this issue in the next week or two.
+The Stellar Development Foundation also uses these same GitHub issues to keep track of what we are
+working on. If you see any issues that are assigned to a particular person or have the `in
+progress` label, that means someone is currently working on that issue in the next week or two.
 
 Of course, feel free to create a new issue if you think something needs to be added or fixed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,10 @@ interested in contributing to. Issues marked with [help wanted][help-wanted] or 
 self-contained and a good place to get started.
 
 The Stellar Development Foundation also uses these same GitHub issues to keep track of what we are
-working on. If you see any issues that are assigned to a particular person or have the `in
-progress` label, that means someone is currently working on that issue in the next week or two.
+working on.
+
+Before starting work on an issue it can be a good idea to communicate on the issue, discussing
+what the solution might look like, and if it would make sense to contribute to it.
 
 Of course, feel free to create a new issue if you think something needs to be added or fixed.
 


### PR DESCRIPTION
I've come to find in extensive analysis of public information that the SDF used to generally refer to itself as Stellar.org in older publications, docs, etc. This line of code from six years ago contains such a legacy nomenclature (_see_ #3). This fix here clarifies the reference entity and work diction.
